### PR TITLE
add "auth" option to proxy difinitions

### DIFF
--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -40,3 +40,4 @@ proxy:
   - host: localhost:8080
     path: <%= /^\/(.*)/ %>
     dest: 'http://localhost:4567/foo/$1'
+    auth: false

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -34,7 +34,7 @@ module OAuth
     end
 
     get '*' do
-      if authorized?
+      if authorized? || !auth_is_required?(env["HTTP_HOST"], env["PATH_INFO"])
         forward
       else
         previous_url(request.path_info)

--- a/lib/oauth/helpers.rb
+++ b/lib/oauth/helpers.rb
@@ -23,5 +23,15 @@ module OAuth
     def find_oauth(provider)
       settings.oauth.find{|h| h["omniauth"] == provider}
     end
+
+    def auth_is_required?(host, path)
+      proxy = Settings.proxy.find{|h| h["host"] == host && Regexp.new(h["path"]) =~ path}
+      unless proxy
+        proxy = Settings.proxy.find{|h| h["host"] == nil && Regexp.new(h["path"]) =~ path}.to_h
+      end
+      required = !proxy.has_key?("auth") || proxy["auth"]
+      session[:authorized] = true unless required
+      required
+    end
   end
 end


### PR DESCRIPTION
認証が必要なアプリケーションと不要なアプリケーションを混在できるよう、
設定ファイルのプロキシ定義に`auth`オプションを追加しました。

`auth`オプションの記載が無い場合は現行通り認証が動作し、
`auth: false`を明示した場合に認証が動作しなくなります。

よろしければマージお願いします。
不要であればリジェクトしてください。
