### PR TITLE
add "domain" option to session difinitions

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -9,7 +9,11 @@ class App < Sinatra::Base
     klass.configure do |app|
       app.set :root,     File.dirname(__FILE__)
       app.set :logging,  true
-      app.set :sessions, key: Settings.session["key"], secret: Settings.session["secret"]
+      if Settings.session["domain"]
+        app.set :sessions, key: Settings.session["key"], secret: Settings.session["secret"], domain: Settings.session["domain"]
+      else
+        app.set :sessions, key: Settings.session["key"], secret: Settings.session["secret"]
+      end
 
       app.helpers Sinatra::ContentFor
       app.register Error::Handler

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -1,6 +1,7 @@
 session:
   key:    omonban.session
   secret: <%= ENV["SESSION_SECRET"] %>
+#  domain: example.com
 
 # array of oauth settings
 oauth:


### PR DESCRIPTION
同一ドメインのサブドメイン間で認証を共用できるよう、
クッキーのドメインを指定する`domain`オプションを追加しました。

`domain`オプションの指定がない場合は現行通りの動作になります。

よろしければマージお願いします。
不要であればリジェクトしてください。
